### PR TITLE
[DS-81] update parsing of time and date for events

### DIFF
--- a/domaine-cms/schemaTypes/events/type_event.jsx
+++ b/domaine-cms/schemaTypes/events/type_event.jsx
@@ -59,7 +59,8 @@ export default defineType({
       options: {
         dateFormat: "MM-DD-YYYY",
         timeFormat: "HH:mm",
-        timeStep: 15
+        timeStep: 15,
+        displayTimeZone: "UTC",
       },
       validation: Rule => Rule.required(),
     }),

--- a/src/layouts/Layout_Event.astro
+++ b/src/layouts/Layout_Event.astro
@@ -25,7 +25,7 @@ const timeOptions: UseDateTimeFormatOptions = {
   minute: 'numeric',
   hour12: content.use24hourFormat ? false : true,
 };
-const timeOptionsTimeZone: UseDateTimeFormatOptions = {
+const timeZoneOptions: UseDateTimeFormatOptions = {
   hour: 'numeric',
   minute: 'numeric',
   hour12: content.use24hourFormat ? false : true,
@@ -36,7 +36,7 @@ const timeOptionsTimeZone: UseDateTimeFormatOptions = {
 const dateTime = new Date(content.dateTime)
 const date = new Intl.DateTimeFormat(locale ? locale : 'en-US', dateOptions).format(dateTime);
 const time = new Intl.DateTimeFormat(locale ? locale : 'en-US', timeOptions).format(dateTime);
-const timeZone = new Intl.DateTimeFormat(locale ? locale : 'en-US', timeOptionsTimeZone).formatToParts(new Date())?.find(part => part.type === 'timeZoneName')?.value
+const timeZone = new Intl.DateTimeFormat(locale ? locale : 'en-US', timeZoneOptions).formatToParts(new Date())?.find(part => part.type === 'timeZoneName')?.value
 
 const BrandLayout = brand === Brands.STUDIO ? LayoutStudio : LayoutDomaine
 ---

--- a/src/layouts/Layout_Event.astro
+++ b/src/layouts/Layout_Event.astro
@@ -18,11 +18,14 @@ const dateOptions: UseDateTimeFormatOptions = {
   weekday: 'long',
   month: 'long',
   day: 'numeric',
-  timeZone: content.timezone ? content.timezone : 'America/New_York',
-  timeZoneName: 'short'
 };
 
 const timeOptions: UseDateTimeFormatOptions = {
+  hour: 'numeric',
+  minute: 'numeric',
+  hour12: content.use24hourFormat ? false : true,
+};
+const timeOptionsTimeZone: UseDateTimeFormatOptions = {
   hour: 'numeric',
   minute: 'numeric',
   hour12: content.use24hourFormat ? false : true,
@@ -33,6 +36,8 @@ const timeOptions: UseDateTimeFormatOptions = {
 const dateTime = new Date(content.dateTime)
 const date = new Intl.DateTimeFormat(locale ? locale : 'en-US', dateOptions).format(dateTime);
 const time = new Intl.DateTimeFormat(locale ? locale : 'en-US', timeOptions).format(dateTime);
+const timeZone = new Intl.DateTimeFormat(locale ? locale : 'en-US', timeOptionsTimeZone).formatToParts(new Date())?.find(part => part.type === 'timeZoneName')?.value
+
 const BrandLayout = brand === Brands.STUDIO ? LayoutStudio : LayoutDomaine
 ---
 
@@ -76,11 +81,11 @@ const BrandLayout = brand === Brands.STUDIO ? LayoutStudio : LayoutDomaine
           <div class="event-details">
             <div class="date">
               <Icon name="icon-calendar" />
-              <span>{date}</span>
+              <span>{date} at {timeZone}</span>
             </div>
             <div class="time">
               <Icon name="icon-clock" />
-              <span>{time}</span>
+              <span>{time} {timeZone}</span>
             </div>
             <div class="location">
               <Icon name="icon-pin" />


### PR DESCRIPTION
[DS-81](https://meetdomaine.atlassian.net/browse/DS-81)

The issue was occurring due to the way Sanity was storing date and time. Sanity uses the browser's timezone when the user sets the date/time and then converts that to UTC, so if the user's timezone is EDT and the time is set to 10am, the browser will convert 10am EDT to UTC, which will be incorrect if we convert that back to a different timezone, in this case it was GMT+1 . This update makes sure the datepicker always displays time zone in UTC to avoid any confusion, and we just add the timezone separately (https://www.sanity.io/docs/studio/datetime-type#displaytimezone-92f3b236a884)

[DS-81]: https://meetdomaine.atlassian.net/browse/DS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ