### PR TITLE
Service Type, Group, and Service page SSR

### DIFF
--- a/src/pages/services/[service_type]/[service_group]/[service].astro
+++ b/src/pages/services/[service_type]/[service_group]/[service].astro
@@ -1,37 +1,49 @@
 ---
+// SERVER RENDERED
 import LayoutService from '../../../../layouts/Layout_Service.astro';
 import { Brands } from '../../../../enums/brands';
-import { getServices } from '../../../../lib/cached-content';
-import { getEnv } from '../../../../lib/getEnv';
+import { sanityClient } from 'sanity:client';
+import { globalSectionsFields } from '../../../../lib/cms-queries';
+import { imageBaseFields } from '../../../../lib/cms-queries';
 
-export const prerender = true // Make page static so it doesn't refetch on each page load
+const { service, service_group, service_type } = Astro.params
 
-export async function getStaticPaths() {
-    const services = await getServices(Brands.DOMAINE)
-    return services.map((service) => {
-        return {
-            params: { 
-                service: service.slug.current,
-                service_group: service.serviceGroup.slug.current,
-                service_type: service.serviceGroup.serviceType.slug.current, 
-            },
-            props: { 
-                content: service
-            }
+const [ serviceType, serviceGroup, serviceContent ] = await Promise.all([
+  sanityClient.fetch(`*[_type == "type_serviceType" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_type}'][0]{ slug }`),
+  sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{ slug }`),
+  sanityClient.fetch(`*[_type == "type_service" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service}'][0]{
+    _id,
+    title,
+    slug,
+    isHidden,
+    excerpt,
+    description,
+    formHeading,
+    formText,
+    hubspotFormId,
+    orderRank,
+    agencyBrands[]->{ _id, name, slug },
+    serviceGroup->{
+        _id,
+        title,
+        slug,
+        formHeading,
+        formText,
+        hubspotFormId,
+        serviceType->{
+            _id,
+            title,
+            slug,
+            formHeading,
+            formText,
+            hubspotFormId
         }
-    })
-}
-
-let serviceContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { service, service_type } = Astro.params
-    const services = await getServices(Brands.DOMAINE)
-    serviceContent = services.find(s => s.slug.current === service)
-} else {
-    const { content } = Astro.props
-    serviceContent = content
-}
+    },
+    pageSectionsDomaine[]{${globalSectionsFields}},
+    metafields{ title, description, image{${imageBaseFields}} },
+  }`)
+])
+if (!serviceContent || !serviceGroup || !serviceType) return Astro.redirect('/404')
 ---
 <LayoutService 
     content={serviceContent}

--- a/src/pages/services/[service_type]/[service_group]/index.astro
+++ b/src/pages/services/[service_type]/[service_group]/index.astro
@@ -1,36 +1,46 @@
 ---
 import LayoutServiceGroup from "../../../../layouts/Layout_ServiceGroup.astro";
 import { Brands } from "../../../../enums/brands";
-import { getServiceGroups } from "../../../../lib/cached-content";
-import { getEnv } from "../../../../lib/getEnv";
+import { sanityClient } from "sanity:client";
+import { globalSectionsFields } from "../../../../lib/cms-queries";
+import { imageBaseFields } from "../../../../lib/cms-queries";
+import { imageFields } from "../../../../lib/cms-queries";
 
-export const prerender = true // Make page static so it doesn't refetch on each page load
+const { service_type, service_group } = Astro.params
 
-export async function getStaticPaths() {
-    const serviceGroups = await getServiceGroups(Brands.DOMAINE)
-    return serviceGroups.map((serviceGroup) => {
-        return {
-            params: { 
-              service_group: serviceGroup.slug.current,
-              service_type: serviceGroup.serviceType.slug.current
-            },
-            props: { 
-              content: serviceGroup
-            }
-        }
-    })
-}
-
-let serviceGroupContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { service_type, service_group } = Astro.params
-    const serviceGroups = await getServiceGroups(Brands.DOMAINE)
-    serviceGroupContent = serviceGroups.find(sg => sg.slug.current === service_group)
-} else {
-    const { content } = Astro.props
-    serviceGroupContent = content
-}
+const [ serviceType, serviceGroupContent ] = await Promise.all([
+  sanityClient.fetch(`*[_type == "type_serviceType" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_type}'][0]{ slug }`),
+  sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
+    _id,
+    title,
+    slug,
+    isHidden,
+    excerpt,
+    description,
+    formHeading,
+    formText,
+    hubspotFormId,
+    orderRank,
+    images[]{${imageFields}},
+    agencyBrands[]->{ _id, name, slug },
+    serviceType->{ _id, title, slug, formHeading, formText, hubspotFormId },
+    "services": *[_type == "type_service" && references(^._id)]{
+      _id,
+      title,
+      slug,
+      isHidden,
+      excerpt,
+      description,
+      orderRank,
+      agencyBrands[]->{ _id, name, slug },
+      serviceGroup->{ _id, title, slug, serviceType->{ _id, title, slug } },
+      metafields{ title, description, image{${imageBaseFields}} }
+    } | order(orderRank),
+    metafields{ title, description, image{${imageBaseFields}} },
+    pageSectionsDomaine[]{${globalSectionsFields}}
+  }`)
+])
+if (!serviceGroupContent || !serviceType) return Astro.redirect('/404')
 ---
 <LayoutServiceGroup
     content={serviceGroupContent}

--- a/src/pages/services/[service_type]/index.astro
+++ b/src/pages/services/[service_type]/index.astro
@@ -1,31 +1,43 @@
 ---
 import LayoutServiceType from "../../../layouts/Layout_ServiceType.astro"
 import { Brands } from "../../../enums/brands"
-import { getServiceTypes } from "../../../lib/cached-content";
-import { getEnv } from "../../../lib/getEnv";
+import { sanityClient } from "sanity:client";
+import { imageFields } from "../../../lib/cms-queries";
+import { imageBaseFields } from "../../../lib/cms-queries";
+import { globalSectionsFields } from "../../../lib/cms-queries";
 
-export const prerender = true // Make page static so it doesn't refetch on each page load
-
-export async function getStaticPaths() {
-    const serviceTypes = await getServiceTypes(Brands.DOMAINE)
-    return serviceTypes.map((serviceType) => {
-        return {
-            params: { service_type: serviceType.slug.current },
-            props: { content: serviceType }
-        }
-    })
-}
-
-let serviceTypeContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { service_type } = Astro.params
-    const serviceTypes = await getServiceTypes(Brands.DOMAINE)
-    serviceTypeContent = serviceTypes.find(st => st.slug.current === service_type)
-} else {
-    const { content } = Astro.props
-    serviceTypeContent = content
-}
+const { service_type } = Astro.params
+console.log(service_type)
+const serviceTypeContent = await sanityClient.fetch(`*[_type == "type_serviceType" && slug.current == '${service_type}'][0]{
+    _id,
+    title,
+    description,
+    slug,
+    agencyBrands[]->{ _id, name, slug },
+    pageSectionsDomaine[]{${globalSectionsFields}},
+    "serviceGroups": *[_type == "type_serviceGroup" && references(^._id) ]{
+        _id,
+        title,
+        description,
+        slug,
+        orderRank,
+        serviceType->{slug},
+        "services": *[_type == "type_service" && references(^._id)] {
+            _id,
+            title,
+            description,
+            slug,
+            orderRank
+        } | order(orderRank)
+    } | order(orderRank),
+    isHidden,
+    excerpt,
+    images[]{${imageFields}},
+    metafields{ title, description, image{${imageBaseFields}} },
+    orderRank
+}`
+)
+if (!serviceTypeContent) return Astro.redirect('/404')
 ---
 <LayoutServiceType 
     content={serviceTypeContent}


### PR DESCRIPTION
- **Remove srcset calcs**
- **Optimize Sanity queries**
- **Remove project definition in Sanity queries**
- **Try client prerender**
- **Remove viewport anim from project card**
- **Temp hide global elements**
- **Hide notification menu + footer**
- **Remove getSVG from project card**
- **Respect logo color via css**
- **Image optimizations**
- **Various optimizations**
- **Remove Astro img**
- **Try Sanity cache headers**
- **Test different fetch strategies**
- **Server defer grid**
- **Move back to Sanity queries directly**
- **Try to optimize filter sanity queries**
- **Dont filter project filters by hasContent**
- **Remove redundant await**
- **Header and Menu fetch optimizations**
- **Optimize blog fetches**
- **Keep queries separate in blog post**
- **Try SSG for all services pages**
- **Make sure Promise works with mixed fetches**
- **blog post optimizations**
- **Service Type page SSR**
- **Service Group page SSR**
- **Service page SSR**
