### PR TITLE
Partners pages SSR

### DIFF
--- a/src/components/global/sections/section-MediaFullbleed.astro
+++ b/src/components/global/sections/section-MediaFullbleed.astro
@@ -9,6 +9,7 @@ const { section, brand, key, media, locale } = Astro.props
     image={section?.media ? section.media.image : media.image}
     autoplay={false}
     sizes="100vw"
+    aspectRatio={1920 / 1080}
   />
 </section>
 

--- a/src/pages/partners/[partner].astro
+++ b/src/pages/partners/[partner].astro
@@ -1,29 +1,43 @@
 ---
+// SERVER RENDERED
 import LayoutPartner from '../../layouts/Layout_Partner.astro';
 import { Brands } from '../../enums/brands';
-import { getPartners } from '../../lib/cached-content';
-import { getEnv } from '../../lib/getEnv';
+import { sanityClient } from 'sanity:client';
+import { imageBaseFields } from '../../lib/cms-queries';
+import { imageFields } from '../../lib/cms-queries';
+import { globalSectionsFields } from '../../lib/cms-queries';
+import { richContentFields } from '../../lib/cms-queries';
+import { Locales } from '../../enums/locales';
 
-export async function getStaticPaths() {
-    const partners = await getPartners(Brands.DOMAINE)
-    return partners.filter((partner) => partner.tier?.createLandingPages).map((partner) => {
-        return {
-            params: { partner: partner.slug.current },
-            props: { content: partner }
-        }
-    })
-}
-
-let partnerContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { partner } = Astro.params
-    const partners = await getPartners(Brands.DOMAINE)
-    partnerContent = partners.find(p => p.slug.current === partner)
-} else {
-    const { content } = Astro.props
-    partnerContent = content
-}
+const { partner } = Astro.params
+const partnerContent = await sanityClient.fetch(`*[_type == "type_partner" && tier->createLandingPages && slug.current == '${partner}'][0]{
+    _id,
+    title, 
+    slug, 
+    excerpt,
+    description,
+    richContent{ 
+        translations{ 
+            ${Object.keys(Locales).filter(locale => Locales[locale] !== "en").map((locale) => (
+                `"${Locales[locale]}": ${Locales[locale]}[]{ _type, _key, children[]{${richContentFields}} }`
+            )).join()}
+        }, 
+        richContent[]{${richContentFields}} 
+    },
+    globalSections{ sections[]{${globalSectionsFields}} },
+    icon{${imageFields}}, 
+    tier->{slug, title, createLandingPages}, 
+    websiteUrl, 
+    websiteText,
+    instagramUrl,
+    twitterUrl,
+    linkedInUrl,
+    youTubeUrl,
+    tikTokUrl,
+    metafields{ title, description, image{${imageBaseFields}} },
+  }`
+)
+if (!partnerContent) return Astro.redirect('/404')
 ---
 <LayoutPartner
     content={partnerContent}

--- a/src/pages/partners/index.astro
+++ b/src/pages/partners/index.astro
@@ -1,6 +1,8 @@
 ---
 import LayoutPartnersIndex from '../../layouts/Layout_PartnersIndex.astro';
 import { Brands } from '../../enums/brands';
+
+export const prerender = true // Make page static so it doesn't refetch on each page load
 ---
 <LayoutPartnersIndex
     brand={Brands.DOMAINE}

--- a/src/pages/services/[service_type]/[service_group]/index.astro
+++ b/src/pages/services/[service_type]/[service_group]/index.astro
@@ -1,4 +1,5 @@
 ---
+// SERVER RENDERED
 import LayoutServiceGroup from "../../../../layouts/Layout_ServiceGroup.astro";
 import { Brands } from "../../../../enums/brands";
 import { sanityClient } from "sanity:client";

--- a/src/pages/services/[service_type]/index.astro
+++ b/src/pages/services/[service_type]/index.astro
@@ -1,4 +1,5 @@
 ---
+// SERVER RENDERED
 import LayoutServiceType from "../../../layouts/Layout_ServiceType.astro"
 import { Brands } from "../../../enums/brands"
 import { sanityClient } from "sanity:client";
@@ -7,7 +8,6 @@ import { imageBaseFields } from "../../../lib/cms-queries";
 import { globalSectionsFields } from "../../../lib/cms-queries";
 
 const { service_type } = Astro.params
-console.log(service_type)
 const serviceTypeContent = await sanityClient.fetch(`*[_type == "type_serviceType" && slug.current == '${service_type}'][0]{
     _id,
     title,

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -1,4 +1,5 @@
 ---
+// STATIC ROUTE
 import { Brands } from "../../enums/brands";
 import { Locales } from "../../enums/locales";
 import LayoutDomaineServices from "../../layouts/Layout-Domaine_ServicesIndex.astro";


### PR DESCRIPTION
- **Remove srcset calcs**
- **Optimize Sanity queries**
- **Remove project definition in Sanity queries**
- **Try client prerender**
- **Remove viewport anim from project card**
- **Temp hide global elements**
- **Hide notification menu + footer**
- **Remove getSVG from project card**
- **Respect logo color via css**
- **Image optimizations**
- **Various optimizations**
- **Remove Astro img**
- **Try Sanity cache headers**
- **Test different fetch strategies**
- **Server defer grid**
- **Move back to Sanity queries directly**
- **Try to optimize filter sanity queries**
- **Dont filter project filters by hasContent**
- **Remove redundant await**
- **Header and Menu fetch optimizations**
- **Optimize blog fetches**
- **Keep queries separate in blog post**
- **Try SSG for all services pages**
- **Make sure Promise works with mixed fetches**
- **blog post optimizations**
- **Service Type page SSR**
- **Service Group page SSR**
- **Service page SSR**
- **Partners pages SSR - fix video aspect ratio on Partners**
