### PR TITLE
Remove spread operators and a bunch of other opimizations

### DIFF
--- a/src/components/global/sections/section-MediaFullbleed.astro
+++ b/src/components/global/sections/section-MediaFullbleed.astro
@@ -14,7 +14,7 @@ const { section, brand, key, media, locale } = Astro.props
 </section>
 
 <style>
-.section-video-fullbleed {
-  position: relative;
-}
+  .section-video-fullbleed {
+    position: relative;
+  }
 </style>

--- a/src/layouts/Layout-Domaine_ServicesIndex.astro
+++ b/src/layouts/Layout-Domaine_ServicesIndex.astro
@@ -8,7 +8,7 @@ import { loadQuery } from "../lib/sanity-load-query";
 
 const { data: pageSettings } = await loadQuery({ 
   query: `*[_type == "page_services-index-domaine"][0]{
-    ...,  
+    _id,
     title,
     heading,
     images[]{${imageFields}},

--- a/src/layouts/Layout_Service.astro
+++ b/src/layouts/Layout_Service.astro
@@ -12,14 +12,14 @@ import SectionGlobalSections from "../components/global/sections/section-GlobalS
 import { blogCardFields, projectGridFields } from "../lib/cms-queries"
 import { sanityClient } from "sanity:client"
 
-export const prerender = false // Make Service content static so it doesn't refetch on each page load
-
 const { content, locale, brand, activePath } = Astro.props;
 
 const BrandLayout = brand === Brands.STUDIO ? LayoutStudio : LayoutDomaine
 
-const relatedProjects = await sanityClient.fetch(`*[_type == "type_project" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->slug.current ]{${projectGridFields} } | order(orderRank)`)
-const relatedPosts = await sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->slug.current ]{${blogCardFields} }|order(postDate desc)`)
+const [ relatedProjects, relatedPosts ] = await Promise.all([
+  sanityClient.fetch(`*[_type == "type_project" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->slug.current ]{${projectGridFields} } | order(orderRank)`),
+  sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->slug.current ]{${blogCardFields} }|order(postDate desc)`)
+])
 ---
 <BrandLayout
   title={`${content.metafields?.title ? getTranslationString(content.metafields.title, locale) : getTranslationString(content.title, locale)} | ${getTranslationString(content.serviceGroup.title, locale)} | ${getTranslationString(content.serviceGroup.serviceType.title, locale)} ${locale ? Translations.SERVICES.locales[locale] : Translations.SERVICES.name}`}

--- a/src/layouts/Layout_ServiceGroup.astro
+++ b/src/layouts/Layout_ServiceGroup.astro
@@ -13,12 +13,13 @@ import { blogCardFields } from "../lib/cms-queries"
 import { projectGridFields } from "../lib/cms-queries"
 import { sanityClient } from "sanity:client"
 
-export const prerender = false // Make Service Group content static so it doesn't refetch on each page load
-
 const { content, locale, brand, activePath } = Astro.props;
 const BrandLayout = brand === Brands.STUDIO ? LayoutStudio : LayoutDomaine
-const relatedProjects = await sanityClient.fetch(`*[_type == "type_project" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->serviceGroup->slug.current ]{${projectGridFields}} | order(orderRank)`)
-const relatedPosts = await sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->serviceGroup->slug.current ]{${blogCardFields}}|order(postDate desc)`)
+
+const [ relatedProjects, relatedPosts ] = await Promise.all([
+  sanityClient.fetch(`*[_type == "type_project" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->serviceGroup->slug.current ]{${projectGridFields}} | order(orderRank)`),
+  sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${brand}' && isHidden != true && '${content.slug.current}' in services[]->serviceGroup->slug.current ]{${blogCardFields}}|order(postDate desc)`)
+])
 ---
 <BrandLayout
     title={`${content.metafields?.title ? getTranslationString(content.metafields.title, locale) : getTranslationString(content.title, locale)} | ${getTranslationString(content.serviceType.title, locale)} ${locale ? Translations.SERVICES.locales[locale] : Translations.SERVICES.name}`}

--- a/src/lib/cached-content.js
+++ b/src/lib/cached-content.js
@@ -233,7 +233,13 @@ export const getProjectIndustries = async (brand) => {
 export const getProjectPageSettings = async (brand) => {
   if (_projectPageSettings[brand]) return _projectPageSettings[brand]
   const projectsIndexId = brand === Brands.STUDIO ? 'page_projects-index-studio' : 'page_projects-index-domaine'
-  const data = await sanityClient.fetch(`*[_type == "page_projects-index" && _id == '${projectsIndexId}'][0]`)
+  const data = await sanityClient.fetch(`*[_type == "page_projects-index" && _id == '${projectsIndexId}'][0]{
+    _id,
+    title,
+    heading,
+    subheading,
+    metafields{ title, description, image{${imageBaseFields}} }
+  }`)
   _projectPageSettings[brand] = data
   return data
 }

--- a/src/lib/cached-content.js
+++ b/src/lib/cached-content.js
@@ -2,7 +2,7 @@ import { loadQuery } from "./sanity-load-query"
 import { sanityClient } from "sanity:client"
 import { Brands } from "../enums/brands"
 import { Locales } from "../enums/locales"
-import { imageBaseFields, imageFields, videoFields, globalSectionsFields, richContentFields, serviceQuery } from "./cms-queries"
+import { imageBaseFields, imageFields, videoFields, globalSectionsFields, richContentFields, serviceQuery, blogCardFields } from "./cms-queries"
 
 let _serviceTypes = {}
 let _serviceGroups = {}
@@ -32,15 +32,32 @@ export const getServiceTypes = async (brand) => {
   if (_serviceTypes[brand]) return _serviceTypes[brand]
   
   const data = await sanityClient.fetch(`*[_type == "type_serviceType" && '${brand}' in agencyBrands[]->name ]{
-    ...,
-    agencyBrands[]->{ ..., name },
+    _id,
+    title,
+    slug,
+    description,
+    formHeading,
+    formText,
+    hubspotFormId,
+    orderRank,
+    agencyBrands[]->{ _id, name, slug },
     pageSectionsDomaine[]{${globalSectionsFields}},
     pageSectionsStudio[]{${globalSectionsFields}},
     "serviceGroups": *[_type == "type_serviceGroup" && references(^._id) ]{
-        ...,
+        _id,
+        title,
+        slug,
+        description,
+        excerpt,
+        orderRank,
         serviceType->{slug},
         "services": *[_type == "type_service" && references(^._id)] {
-            ...
+            _id,
+            title,
+            slug,
+            description,
+            excerpt,
+            orderRank
         } | order(orderRank)
     } | order(orderRank),
     isHidden,
@@ -57,14 +74,20 @@ export const getServiceGroups = async (brand) => {
   if (_serviceGroups[brand]) return _serviceGroups[brand]
   
   const data = await sanityClient.fetch(`*[_type == "type_serviceGroup" && '${brand}' in agencyBrands[]->name ]{
-    ...,
+    _id,
+    title,
+    slug,
+    orderRank,
     isHidden,
     excerpt,
     description,
+    formHeading,
+    formText,
+    hubspotFormId,
     images[]{${imageFields}},
-    agencyBrands[]->{..., slug },
-    serviceType->{..., formHeading, formText, hubspotFormId },
-    "services": *[_type == "type_service" && references(^._id)]{..., ${serviceQuery} } | order(orderRank),
+    agencyBrands[]->{ _id, name, slug },
+    serviceType->{ _id, title, slug, formHeading, formText, hubspotFormId },
+    "services": *[_type == "type_service" && references(^._id)]{ _id, title, slug, description, excerpt, orderRank } | order(orderRank),
     metafields{ title, description, image{${imageBaseFields}} },
     pageSectionsDomaine[]{${globalSectionsFields}},
     pageSectionsStudio[]{${globalSectionsFields}},
@@ -80,20 +103,27 @@ export const getServices = async (brand) => {
   if (_services[brand]) return _services[brand]
   
   const data = await sanityClient.fetch(`*[_type == "type_service" && '${brand}' in agencyBrands[]->name ]{
-    ...,
+    _id,
+    title,
+    slug,
+    orderRank,
     isHidden,
     excerpt,
     description,
-    agencyBrands[]->{..., slug, name},
+    formHeading,
+    formText,
+    hubspotFormId,
+    agencyBrands[]->{ _id, slug, name},
     serviceGroup->{
-        ..., 
-        serviceType->{...},
-        _id
+        _id,
+        title,
+        slug,
+        serviceType->{ _id, title, slug }
     },
     pageSectionsDomaine[]{${globalSectionsFields}},
     pageSectionsStudio[]{${globalSectionsFields}},
     metafields{ title, description, image{${imageBaseFields}} },
-  } | order(postDate desc)`)
+  } | order(orderRank)`)
 
   _services[brand] = data
   return data
@@ -103,30 +133,10 @@ export const getServices = async (brand) => {
 export const getBlogPosts = async (brand) => {
   if (_blogPosts[brand]) return _blogPosts[brand]
   const data = await sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${brand}' && isHidden != true ]{
-    ..., 
-    _id,
-    slug,
-    authors[]->{name, role, bio, image{${imageFields}}, department->{title} },
-    postDate,
-    thumbnailImage{${imageFields}},
-    category->{..., slug{...} }, 
-    body{
-      ..., 
-      richContent[]{${richContentFields}},
-      translations{ 
-          ${Object.keys(Locales).filter(locale => Locales[locale] !== "en").map((locale) => (
-            `"${Locales[locale]}": ${Locales[locale]}[]{ ..., children[]{${richContentFields}} }`
-          )
-        ).join()}
-      },
-    },
-    services[]->{...},
-    agencyBrand->{slug, name },
-    globalSections{ sections[]{${globalSectionsFields}} },
-    metafields{ title, description, image{${imageBaseFields}} },
+    ${blogCardFields}
   } | order(postDate desc)`)
 
-  // _blogPosts[brand] = await data
+  _blogPosts[brand] = data
   return data
 }
 
@@ -134,11 +144,8 @@ export const getBlogCategories = async (brand) => {
   if (_blogCategories[brand]) return _blogCategories[brand]
   
   const data = await sanityClient.fetch(`*[_type == "type_blogCategory" && defined(*[_type == "type_blog" && isHidden != true && agencyBrand->name == '${brand}' && references(^._id)][0])]{
-    ...,
-    "posts": *[_type == "type_blog" && isHidden != true && agencyBrand->name == '${brand}' && references(^._id)][0]{slug},
-    "hasContent": {
-      "${brand}": defined(*[_type == "type_blog" && isHidden != true && agencyBrand->name == '${brand}' && references(^._id)][0]),
-    },
+    title,
+    slug,
     metafields{ title, description, image{${imageBaseFields}} }
   } | order(title.text asc)`)
 

--- a/src/pages/insights/[category]/index.astro
+++ b/src/pages/insights/[category]/index.astro
@@ -9,13 +9,14 @@ import { Locales } from '../../../enums/locales';
 const { category } = Astro.params
 
 const categoryContent = await sanityClient.fetch(`
-*[_type == "type_blogCategory" && defined(*[_type == "type_blog" && agencyBrand->name == '${Brands.DOMAINE}' && references(^._id)][0]) && slug.current == '${category}'][0]{
+*[_type == "type_blogCategory" && slug.current == '${category}'][0]{
     title,
     heading,
     slug,
     "posts": *[_type == "type_blog" && agencyBrand->name == '${Brands.DOMAINE}' && isHidden != true && category->slug.current == '${category}' ]{ ${blogCardFields} }|order(postDate desc),
     metafields{ title, description, image{${imageBaseFields}} }
 }`)
+if (!categoryContent || categoryContent.posts.length === 0) return Astro.redirect('/404')
 ---
 <LayoutBlogIndex
     blogPosts={categoryContent.posts}

--- a/src/pages/services/[service_type]/[service_group]/[service].astro
+++ b/src/pages/services/[service_type]/[service_group]/[service].astro
@@ -8,10 +8,7 @@ import { imageBaseFields } from '../../../../lib/cms-queries';
 
 const { service, service_group, service_type } = Astro.params
 
-const [ serviceType, serviceGroup, serviceContent ] = await Promise.all([
-  sanityClient.fetch(`*[_type == "type_serviceType" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_type}'][0]{ slug }`),
-  sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{ slug }`),
-  sanityClient.fetch(`*[_type == "type_service" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service}'][0]{
+const serviceContent = await sanityClient.fetch(`*[_type == "type_service" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service}'][0]{
     _id,
     title,
     slug,
@@ -41,9 +38,9 @@ const [ serviceType, serviceGroup, serviceContent ] = await Promise.all([
     },
     pageSectionsDomaine[]{${globalSectionsFields}},
     metafields{ title, description, image{${imageBaseFields}} },
-  }`)
-])
-if (!serviceContent || !serviceGroup || !serviceType) return Astro.redirect('/404')
+  }`
+)
+if (!serviceContent || serviceContent.serviceGroup.slug.current !== service_group || serviceContent.serviceGroup.serviceType.slug.current !== service_type) return Astro.redirect('/404')
 ---
 <LayoutService 
     content={serviceContent}

--- a/src/pages/services/[service_type]/[service_group]/[service].astro
+++ b/src/pages/services/[service_type]/[service_group]/[service].astro
@@ -9,26 +9,21 @@ import { imageBaseFields } from '../../../../lib/cms-queries';
 const { service, service_group, service_type } = Astro.params
 
 const serviceContent = await sanityClient.fetch(`*[_type == "type_service" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service}'][0]{
-    _id,
     title,
     slug,
-    isHidden,
     excerpt,
     description,
     formHeading,
     formText,
     hubspotFormId,
-    orderRank,
-    agencyBrands[]->{ _id, name, slug },
+    agencyBrands[]->{ name },
     serviceGroup->{
-        _id,
         title,
         slug,
         formHeading,
         formText,
         hubspotFormId,
         serviceType->{
-            _id,
             title,
             slug,
             formHeading,

--- a/src/pages/services/[service_type]/[service_group]/index.astro
+++ b/src/pages/services/[service_type]/[service_group]/index.astro
@@ -9,39 +9,35 @@ import { imageFields } from "../../../../lib/cms-queries";
 
 const { service_type, service_group } = Astro.params
 
-const [ serviceType, serviceGroupContent ] = await Promise.all([
-  sanityClient.fetch(`*[_type == "type_serviceType" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_type}'][0]{ slug }`),
-  sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
+const serviceGroupContent = sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
+  title,
+  slug,
+  isHidden,
+  excerpt,
+  description,
+  formHeading,
+  formText,
+  hubspotFormId,
+  orderRank,
+  images[]{${imageFields}},
+  agencyBrands[]->{ _id, name, slug },
+  serviceType->{ _id, title, slug, formHeading, formText, hubspotFormId },
+  "services": *[_type == "type_service" && references(^._id)]{
     _id,
     title,
     slug,
     isHidden,
     excerpt,
     description,
-    formHeading,
-    formText,
-    hubspotFormId,
     orderRank,
-    images[]{${imageFields}},
     agencyBrands[]->{ _id, name, slug },
-    serviceType->{ _id, title, slug, formHeading, formText, hubspotFormId },
-    "services": *[_type == "type_service" && references(^._id)]{
-      _id,
-      title,
-      slug,
-      isHidden,
-      excerpt,
-      description,
-      orderRank,
-      agencyBrands[]->{ _id, name, slug },
-      serviceGroup->{ _id, title, slug, serviceType->{ _id, title, slug } },
-      metafields{ title, description, image{${imageBaseFields}} }
-    } | order(orderRank),
-    metafields{ title, description, image{${imageBaseFields}} },
-    pageSectionsDomaine[]{${globalSectionsFields}}
-  }`)
-])
-if (!serviceGroupContent || !serviceType) return Astro.redirect('/404')
+    serviceGroup->{ _id, title, slug, serviceType->{ _id, title, slug } },
+    metafields{ title, description, image{${imageBaseFields}} }
+  } | order(orderRank),
+  metafields{ title, description, image{${imageBaseFields}} },
+  pageSectionsDomaine[]{${globalSectionsFields}}
+}`)
+if (!serviceGroupContent || serviceGroupContent.serviceType.slug.current !== service_type) return Astro.redirect('/404')
 ---
 <LayoutServiceGroup
     content={serviceGroupContent}

--- a/src/pages/services/[service_type]/[service_group]/index.astro
+++ b/src/pages/services/[service_type]/[service_group]/index.astro
@@ -9,7 +9,7 @@ import { imageFields } from "../../../../lib/cms-queries";
 
 const { service_type, service_group } = Astro.params
 
-const serviceGroupContent = sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
+const serviceGroupContent = await sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
   title,
   slug,
   isHidden,
@@ -37,7 +37,7 @@ const serviceGroupContent = sanityClient.fetch(`*[_type == "type_serviceGroup" &
   metafields{ title, description, image{${imageBaseFields}} },
   pageSectionsDomaine[]{${globalSectionsFields}}
 }`)
-if (!serviceGroupContent || serviceGroupContent.serviceType.slug.current !== service_type) return Astro.redirect('/404')
+if (!serviceGroupContent || serviceGroupContent.serviceType?.slug.current !== service_type) return Astro.redirect('/404')
 ---
 <LayoutServiceGroup
     content={serviceGroupContent}

--- a/src/pages/work/[project].astro
+++ b/src/pages/work/[project].astro
@@ -34,7 +34,6 @@ const projectContent = await sanityClient.fetch(`*[_type == "type_project" && is
         orderRank,
     }[0]`
   )
-console.log(projectContent.awards)
 if (projectContent === null) return Astro.redirect('/404')
 ---
 <LayoutProject 

--- a/src/pages/work/industries/[industry].astro
+++ b/src/pages/work/industries/[industry].astro
@@ -8,7 +8,10 @@ import { getCollection } from 'astro:content';
 
 const { industry } = Astro.params
 const industryContent = await sanityClient.fetch(`*[_type == "type_industry" && slug.current == '${industry}'][0]{ 
-    ...,
+    _id,
+    title,
+    slug,
+    description,
     excerpt,
     "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.DOMAINE}' && isHidden != true && references(^._id) ]{ ${projectGridFields} } | order(orderRank),
     metafields{ title, description, image{${imageBaseFields}} },


### PR DESCRIPTION
- **Remove srcset calcs**
- **Optimize Sanity queries**
- **Remove project definition in Sanity queries**
- **Try client prerender**
- **Remove viewport anim from project card**
- **Temp hide global elements**
- **Hide notification menu + footer**
- **Remove getSVG from project card**
- **Respect logo color via css**
- **Image optimizations**
- **Various optimizations**
- **Remove Astro img**
- **Try Sanity cache headers**
- **Test different fetch strategies**
- **Server defer grid**
- **Move back to Sanity queries directly**
- **Try to optimize filter sanity queries**
- **Dont filter project filters by hasContent**
- **Remove redundant await**
- **Header and Menu fetch optimizations**
- **Optimize blog fetches**
- **Keep queries separate in blog post**
- **Try SSG for all services pages**
- **Make sure Promise works with mixed fetches**
- **blog post optimizations**
- **Service Type page SSR**
- **Service Group page SSR**
- **Service page SSR**
- **Partners pages SSR - fix video aspect ratio on Partners**
- **Service pages optimizations**
- **Await serviceGroup query**
- **Optimize filter query content**
- **Remove spread operators**
