### PR TITLE
Fix memory leak from clock timers

### DIFF
--- a/src/components/global/header/global-NotificationMenu.astro
+++ b/src/components/global/header/global-NotificationMenu.astro
@@ -147,7 +147,7 @@ const upcomingEvents = events.filter((event) => !event.isPrivate && !checkDateIs
 
 <script>
   import { isMobileBreakpoint } from "../../../lib/check-device"
-  import { getIsDaytime, getLocalTime } from "../../../lib/get-local-time"
+  import { getIsDaytime, getLocalTime, clearTimeIntervals } from "../../../lib/get-local-time"
   const notificationMenu = document.getElementById('notification-menu')
   const notificationToggle: HTMLElement = document.getElementById('notification-toggle')
   const clocks = notificationMenu.querySelectorAll('.clock')
@@ -158,6 +158,7 @@ const upcomingEvents = events.filter((event) => !event.isPrivate && !checkDateIs
 
   let pageEndOpen = false
   let currentScroll = window.scrollY
+  let timeUpdateInterval: number | null = null
 
   if (!isMobileBreakpoint) {
     window.addEventListener("scroll", (e) => {
@@ -177,30 +178,36 @@ const upcomingEvents = events.filter((event) => !event.isPrivate && !checkDateIs
     })
   }
 
-  const updateTime = () => {
-      
-      clocks.forEach((clock: HTMLElement) => {
-        let time, hours, minutes, seconds
-        
-        const timezoneId = clock.dataset.timezone
-        const cleanedTimezoneId = timezoneId?.replace(/[\u200B-\u200D\uFEFF]/g, '').trim()
-        const timeElement: HTMLElement = clock.querySelector('.time')
+  // Initialize time displays once without intervals
+  const initializeTime = () => {
+    clocks.forEach((clock: HTMLElement) => {
+      const timezoneId = clock.dataset.timezone
+      const cleanedTimezoneId = timezoneId?.replace(/[\u200B-\u200D\uFEFF]/g, '').trim()
+      const timeElement: HTMLElement = clock.querySelector('.time')
 
-        time = new Date(new Date().toLocaleString("en-US", {timeZone: cleanedTimezoneId} ));
-        hours = time.getHours()
-        minutes = time.getMinutes()
-        seconds = time.getSeconds()
+      // Clear any existing intervals
+      clearTimeIntervals(timeElement)
+      clearTimeIntervals(clock)
 
-        getLocalTime(timeElement, cleanedTimezoneId, 'innerText')
-        getLocalTime(clock, cleanedTimezoneId, 'customProps')
-        getIsDaytime(clock, cleanedTimezoneId)
-        
-      })
-    }
+      // Set up new intervals and store their IDs
+      getLocalTime(timeElement, cleanedTimezoneId, 'innerText')
+      getLocalTime(clock, cleanedTimezoneId, 'customProps')
+      getIsDaytime(clock, cleanedTimezoneId)
+    })
+  }
 
-    if (!isMobileBreakpoint) {
-      setInterval(updateTime, 1000)
-    }
+  if (!isMobileBreakpoint) {
+    initializeTime()
+  }
+
+  // Clean up intervals when page unloads
+  window.addEventListener('beforeunload', () => {
+    clocks.forEach((clock: HTMLElement) => {
+      const timeElement: HTMLElement = clock.querySelector('.time')
+      clearTimeIntervals(timeElement)
+      clearTimeIntervals(clock)
+    })
+  })
   
 </script>
 

--- a/src/components/global/practices/global-practicesGrid.astro
+++ b/src/components/global/practices/global-practicesGrid.astro
@@ -79,14 +79,23 @@ const { locale } = Astro.props
   </div>
 
 <script>
-  import { getLocalTime, getIsDaytime } from "../../../lib/get-local-time"
+  import { getLocalTime, getIsDaytime, clearTimeIntervals } from "../../../lib/get-local-time"
   const clocks = Array.from(document.getElementsByClassName('location-clock') as HTMLCollectionOf<HTMLElement>)
   const icons = Array.from(document.getElementsByClassName('location-time-icon') as HTMLCollectionOf<HTMLElement>)
   // clocks.forEach(clock => {
   //   getLocalTime(clock, clock.dataset.timezone, 'innerText')
   // });
   icons.forEach((icon) => {
+    // Clear any existing intervals
+    clearTimeIntervals(icon)
     getIsDaytime(icon, icon.dataset.timezone)
+  })
+
+  // Clean up intervals when page unloads
+  window.addEventListener('beforeunload', () => {
+    icons.forEach((icon) => {
+      clearTimeIntervals(icon)
+    })
   })
 </script>
 

--- a/src/components/global/sections/section-LocationsFeed.astro
+++ b/src/components/global/sections/section-LocationsFeed.astro
@@ -45,13 +45,26 @@ const locations = await sanityClient.fetch(`*[_type == "type_location"]{
 </section>
 
 <script>
-import { getLocalTime } from "../../../lib/get-local-time"
+import { getLocalTime, clearTimeIntervals } from "../../../lib/get-local-time"
   window.addEventListener("DOMContentLoaded", () => {
     const sections = Array.from(document.getElementsByClassName('section-locations-feed') as HTMLCollectionOf<HTMLElement>) 
     sections.forEach((section) => {
       const clocks = Array.from(section.getElementsByClassName('location-time') as HTMLCollectionOf<HTMLElement>)
       clocks.forEach((clock) => {
+        // Clear any existing intervals
+        clearTimeIntervals(clock)
         getLocalTime(clock, clock.dataset.timezone, "innerText")
+      })
+    })
+  })
+
+  // Clean up intervals when page unloads
+  window.addEventListener('beforeunload', () => {
+    const sections = Array.from(document.getElementsByClassName('section-locations-feed') as HTMLCollectionOf<HTMLElement>) 
+    sections.forEach((section) => {
+      const clocks = Array.from(section.getElementsByClassName('location-time') as HTMLCollectionOf<HTMLElement>)
+      clocks.forEach((clock) => {
+        clearTimeIntervals(clock)
       })
     })
   })

--- a/src/layouts/Layout-Global.astro
+++ b/src/layouts/Layout-Global.astro
@@ -133,12 +133,6 @@ const visualEditingEnabled = getEnv('PUBLIC_SANITY_VISUAL_EDITING_ENABLED', Astr
 		<slot />
 		<ViewportAnimation />
 
-    <!-- Front chat integration -->
-    <script src='https://chat-assets.frontapp.com/v1/chat.bundle.js' is:inline></script>
-    <script is:inline>
-      window.FrontChat('init', {chatId: '065bffd753c9111b8275e69a65e7ff26', useDefaultLauncher: true});
-    </script>
-
 	</body>
 </html>
 

--- a/src/lib/get-local-time.ts
+++ b/src/lib/get-local-time.ts
@@ -25,7 +25,12 @@ export const getLocalTime = (element: HTMLElement, timezone: string, mode: strin
     }
 
     updateTime()
-    setInterval(updateTime, 1000)
+    const intervalId = setInterval(updateTime, 1000)
+    
+    // Store interval ID on element so it can be cleared later
+    element.dataset.timeInterval = intervalId.toString()
+    
+    return intervalId
 }
 
 export const getIsDaytime = (element: HTMLElement, timezone: string ) => {
@@ -43,6 +48,23 @@ export const getIsDaytime = (element: HTMLElement, timezone: string ) => {
   }
 
   updateTime()
-  setInterval(updateTime, 1000)
+  const intervalId = setInterval(updateTime, 1000)
+  
+  // Store interval ID on element so it can be cleared later
+  element.dataset.daytimeInterval = intervalId.toString()
+  
+  return intervalId
+}
+
+// Helper function to clear all time intervals
+export const clearTimeIntervals = (element: HTMLElement) => {
+  if (element.dataset.timeInterval) {
+    clearInterval(parseInt(element.dataset.timeInterval))
+    delete element.dataset.timeInterval
+  }
+  if (element.dataset.daytimeInterval) {
+    clearInterval(parseInt(element.dataset.daytimeInterval))
+    delete element.dataset.daytimeInterval
+  }
 }
 


### PR DESCRIPTION
- **Remove srcset calcs**
- **Optimize Sanity queries**
- **Remove project definition in Sanity queries**
- **Try client prerender**
- **Remove viewport anim from project card**
- **Temp hide global elements**
- **Hide notification menu + footer**
- **Remove getSVG from project card**
- **Respect logo color via css**
- **Image optimizations**
- **Various optimizations**
- **Remove Astro img**
- **Try Sanity cache headers**
- **Test different fetch strategies**
- **Server defer grid**
- **Move back to Sanity queries directly**
- **Try to optimize filter sanity queries**
- **Dont filter project filters by hasContent**
- **Remove redundant await**
- **Header and Menu fetch optimizations**
- **Optimize blog fetches**
- **Keep queries separate in blog post**
- **Try SSG for all services pages**
- **Make sure Promise works with mixed fetches**
- **blog post optimizations**
- **Service Type page SSR**
- **Service Group page SSR**
- **Service page SSR**
- **Partners pages SSR - fix video aspect ratio on Partners**
- **Service pages optimizations**
- **Await serviceGroup query**
- **Optimize filter query content**
- **Remove spread operators**
- **Remove front chat**
- **Clear time intervals, causing Cloudflare timeouts**
