### PR TITLE
All pages SSR

### DIFF
--- a/src/components/global/blog/blog-PostHero.astro
+++ b/src/components/global/blog/blog-PostHero.astro
@@ -20,6 +20,7 @@ const formattedDate = formatDate(post.postDate)
             sizes="50vw"
             aspectRatio={3 / 4}
             cover={true}
+            eager={true}
         />
     </div>
     <div class="section-content">

--- a/src/components/global/blog/global-BlogCard.astro
+++ b/src/components/global/blog/global-BlogCard.astro
@@ -14,9 +14,10 @@ interface Props {
   agencyBrand: any;
   postDate: any;
   locale: string;
+  eager?: boolean;
 }
 
-const { title, series, thumbnailImage, slug, category, agencyBrand, postDate, locale } = Astro.props;
+const { title, series, thumbnailImage, slug, category, agencyBrand, postDate, locale, eager } = Astro.props;
 
 const categoryUrl = `${agencyBrand.slug.current == "/studio" ? "/studio" : ""}/insights/${category.slug.current}`;
 const postUrl = `${categoryUrl}/${slug.current}`;
@@ -37,6 +38,7 @@ const formattedDate = formatDate(postDate);
       image={thumbnailImage.image}
       aspectRatio={3 / 4}
       sizes="30vw"
+      eager={eager}
     />
   </a>
   <div class="card-text">

--- a/src/components/global/blog/global-BlogGrid.astro
+++ b/src/components/global/blog/global-BlogGrid.astro
@@ -9,7 +9,7 @@ interface Props {
 const { blogPosts, locale } = Astro.props
 ---
 <div class="blog-grid">
-    {blogPosts.map((blogPost) => (
+    {blogPosts.map((blogPost, i) => (
         <GlobalBlogCard 
             title={blogPost.title}
             series={blogPost.series}
@@ -19,6 +19,7 @@ const { blogPosts, locale } = Astro.props
             thumbnailImage={blogPost.thumbnailImage}
             agencyBrand={blogPost.agencyBrand}
             locale={locale}
+            eager={i < 3 ? true : false}
         />
     ))}
 </div>

--- a/src/components/global/projects/global-ProjectCard.astro
+++ b/src/components/global/projects/global-ProjectCard.astro
@@ -11,9 +11,10 @@ import { getEnv } from '../../../lib/getEnv';
 interface Props {
   project: ProjectCard;
   locale?: string;
+  eager?: boolean;
 }
 
-const { project, locale } = Astro.props;
+const { project, locale, eager } = Astro.props;
 ---
 
 <a
@@ -28,6 +29,7 @@ const { project, locale } = Astro.props;
         aspectRatio={3 / 4}
         sizes="(width <= 768px) 50vw, 33vw"
         maxWidth={960}
+        eager={eager}
       />
     </div>
     {project.client?.logo && (

--- a/src/components/global/projects/global-ProjectsGrid.astro
+++ b/src/components/global/projects/global-ProjectsGrid.astro
@@ -4,10 +4,11 @@ const { projects, heading, locale } = Astro.props
 ---
 <div class="projects-grid">
     {heading && <h2>{heading}</h2>}
-    {projects.map((project) => (
+    {projects.map((project, i) => (
         <GlobalProjectCard
             project={project}
             locale={locale}
+            eager={i < 3 ? true : false}
         />
     ))}
 </div>

--- a/src/components/global/projects/workPost-Hero.astro
+++ b/src/components/global/projects/workPost-Hero.astro
@@ -1,8 +1,5 @@
 ---
-import { getTranslationString } from "../../../lib/translations"
-import AtomSanityImage from "../atoms/atom-sanityImage.astro"
 import AtomSanityMedia from "../atoms/atom-sanityMedia.astro"
-import { paths } from "../../../lib/paths"
 
 const { title, heroMedia, accentColor, locale } = Astro.props
 ---
@@ -19,6 +16,7 @@ const { title, heroMedia, accentColor, locale } = Astro.props
             cover={true}
             sizes="100vw"
             autoplay={true}
+            eager={true}
         />
     </div>
 </section>

--- a/src/components/global/services/serviceGroup-Hero.astro
+++ b/src/components/global/services/serviceGroup-Hero.astro
@@ -1,12 +1,13 @@
 ---
 import AtomServiceLink from "../atoms/atom-serviceLink.astro"
+import { Brands } from "../../../enums/brands"
 
 const { serviceGroup, brand } = Astro.props
 ---
 <section class="service-group-hero">
     <div class="breadcrumbs">
-        <a class="h5" href={`${brand === "studio" ? "/studio" : ""}/services/`}>Services</a> /
-        <a href={`${brand === "studio" ? "/studio" : ""}/services/${serviceGroup.serviceType.slug.current}`} class="h5">{serviceGroup.serviceType.title}</a>
+        <a class="h5" href={`${brand === Brands.STUDIO ? "/studio" : ""}/services/`}>Services</a> /
+        <a href={`${brand === Brands.STUDIO ? "/studio" : ""}/services/${serviceGroup.serviceType.slug.current}`} class="h5">{serviceGroup.serviceType.title}</a>
     </div>
     <h1>{serviceGroup.title}</h1>
     {serviceGroup.description && <p>{serviceGroup.description}</p>}

--- a/src/components/studio/sections/home/home-Hero.astro
+++ b/src/components/studio/sections/home/home-Hero.astro
@@ -53,6 +53,7 @@ const iconText = replaceStringIcons(getTranslationString(heading, locale))
                 >
                     <AtomSanityImage 
                         sizes="50vw"
+                        eager={true}
                         image={projectCard.image ? projectCard.image.image : projectCard.project.thumbnailMedia.image}
                     />
                 </a>

--- a/src/layouts/Layout-Global.astro
+++ b/src/layouts/Layout-Global.astro
@@ -117,7 +117,7 @@ const visualEditingEnabled = getEnv('PUBLIC_SANITY_VISUAL_EDITING_ENABLED', Astr
 		<!-- End Google Tag Manager (noscript) -->
 
 		<!-- <ClientRouter /> -->
-		<!-- <VisualEditing enabled={visualEditingEnabled} /> -->
+		<!-- <VisualEditing enabled={true} /> -->
 
     <GlobalPreloader
       showPreloader={showPreloader}

--- a/src/layouts/Layout-Studio.astro
+++ b/src/layouts/Layout-Studio.astro
@@ -5,15 +5,12 @@ import Footer from '../components/global/global-Footer.astro';
 import { getTranslationString } from '../lib/translations';
 import { Brands } from '../enums/brands';
 import GlobalMarketingHeader from '../components/global/marketingHeader/global-MarketingHeader.astro';
-import { loadQuery } from '../lib/sanity-load-query';
-import { richContentFields, imageBaseFields } from '../lib/cms-queries';
 import { getEntry } from 'astro:content';
 
 interface Props {
 	title: string,
 	description?: string,
 	image?: string,
-	theme?: string,
     searchFilter?: string,
     activePath?: string,
     searchExposed?: boolean,
@@ -26,11 +23,17 @@ interface Props {
     indexSearch?: boolean;
 }
 
-const { title, description, image, theme, searchFilter, activePath, searchExposed, showPreloader, locale, marketingHeader, marketingHeaderButtonLabel, indexSearch } = Astro.props;
+const { title, description, image, searchFilter, activePath, searchExposed, showPreloader, locale, marketingHeader, marketingHeaderButtonLabel, indexSearch } = Astro.props;
 
-const { data: headerSettings} = await getEntry('globalSettingsStudio', 'headerSettings')
-const { data: footerSettings} = await getEntry('globalSettingsStudio', 'footerSettings')
-const { data: brandSettings} = await getEntry('globalSettingsStudio', 'brandSettings')
+const [
+    { data: headerSettings},
+    { data: footerSettings},
+    { data: brandSettings}
+] = await Promise.all([
+    getEntry('globalSettingsStudio', 'headerSettings'),
+    getEntry('globalSettingsStudio', 'footerSettings'),
+    getEntry('globalSettingsStudio', 'brandSettings')
+])
 ---
 <LayoutGlobal
     title={`${title ? title : "Domaine Studio"} | ${getTranslationString(brandSettings.metafields.title, locale)}`}
@@ -59,13 +62,6 @@ const { data: brandSettings} = await getEntry('globalSettingsStudio', 'brandSett
             brand={Brands.STUDIO}
         />
     }
-
-    <!-- <Header
-        currentBrand={brandSettings}
-        activePath={activePath}
-        searchExposed={searchExposed}
-        brand={Brands.STUDIO}
-    /> -->
 
     <main>
         <slot />

--- a/src/layouts/Layout-Studio_Home.astro
+++ b/src/layouts/Layout-Studio_Home.astro
@@ -12,7 +12,6 @@ const { content, locale } = Astro.props
     description={content.metafields?.description ? getTranslationString(content.metafields.description, locale) : null}
     image={content.metafields?.image ? urlFor(content.metafields.image).url() : null}
     locale={locale}
-    theme="dark"
     searchExposed={true}
     showPreloader={content.showPreloader}
 >

--- a/src/layouts/Layout_Event.astro
+++ b/src/layouts/Layout_Event.astro
@@ -53,6 +53,7 @@ const BrandLayout = brand === Brands.STUDIO ? LayoutStudio : LayoutDomaine
         image={content.thumbnailImage.image}
         aspectRatio={3 / 4}
         cover={true}
+        eager={true}
       />
     </div>
 

--- a/src/layouts/Layout_Service.astro
+++ b/src/layouts/Layout_Service.astro
@@ -36,11 +36,11 @@ const [ relatedProjects, relatedPosts ] = await Promise.all([
       breadcrumbs={[
           {
               title: 'Services /',
-              url: `${Astro.url.origin}${brand === Brands.STUDIO ? '/studio/' : '/'}services/`
+              url: `${brand === Brands.STUDIO ? '/studio/' : '/'}services/`
           },
           {
               title: content.serviceGroup.serviceType?.title,
-              url: `${Astro.url.origin}${brand === Brands.STUDIO ? '/studio/' : '/'}services/${content.serviceGroup.serviceType?.slug.current}`
+              url: `${brand === Brands.STUDIO ? '/studio/' : '/'}services/${content.serviceGroup.serviceType?.slug.current}`
           }
       ]}
       locale={locale}

--- a/src/layouts/Layout_ServiceGroup.astro
+++ b/src/layouts/Layout_ServiceGroup.astro
@@ -35,11 +35,11 @@ const [ relatedProjects, relatedPosts ] = await Promise.all([
         breadcrumbs={[
           {
               title: 'Services /',
-              url: `${Astro.url.origin}${brand === Brands.STUDIO ? '/studio/' : '/'}services/`
+              url: `${brand === Brands.STUDIO ? '/studio/' : '/'}services/`
           },
           {
               title: content.serviceType.title,
-              url: `${Astro.url.origin}${brand === Brands.STUDIO ? '/studio/' : '/'}services/${content.serviceType.slug.current}`
+              url: `${brand === Brands.STUDIO ? '/studio/' : '/'}services/${content.serviceType.slug.current}`
           },
         ]}
         locale={locale}

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -11,7 +11,7 @@ const { data: pageContent } = await loadQuery({
     query: `*[_type == "page_general" && slug.current == '${page}']{${generalPageFields}}[0]`
 })
 
-if (pageContent === null) return Astro.redirect('/404')
+if (!pageContent) return Astro.redirect('/404')
 ---
 {pageContent?.isMarketingPage ? 
     <LayoutMarketingPage

--- a/src/pages/events/[event].astro
+++ b/src/pages/events/[event].astro
@@ -2,50 +2,37 @@
 import LayoutEvent from "../../layouts/Layout_Event.astro";
 import { loadQuery } from "../../lib/sanity-load-query";
 import { imageFields, globalSectionsFields } from "../../lib/cms-queries";
-import { getEnv } from "../../lib/getEnv";
+import { Locales } from "../../enums/locales";
 
-export const prerender = false // Make Event content static so it doesn't refetch on each page load
-
-export async function getStaticPaths() {
-    const { data: events } = await loadQuery({ 
-      query: `*[_type == "type_event"]{
-        ...,
-        dateTime,
-        partnerLogos[]{${imageFields}},
-        speakers[]{..., speakerImage{${imageFields}}, speakerLogo{${imageFields}} },
-        thumbnailImage{${imageFields}},
-        globalSections{ sections[]{${globalSectionsFields}}},
-      } | order(dateTime)`
-    })
-    return events.map((event) => {
-        return {
-            params: { event: event.slug.current },
-            props: { content: event }
-        }
-    })
-}
-
-let eventContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { event } = Astro.params
-    const { data } = await loadQuery({ 
-      query: `*[_type == "type_event" && slug.current == $slug][0]{
-        ...,
-        dateTime,
-        partnerLogos[]{${imageFields}},
-        speakers[]{..., speakerImage{${imageFields}}, speakerLogo{${imageFields}} },
-        thumbnailImage{${imageFields}},
-        globalSections{ sections[]{${globalSectionsFields}}},
-      }`,
-      params: { slug: event }
-    })
-    eventContent = data
-} else {
-    const { content } = Astro.props
-    eventContent = content
-}
+const { event } = Astro.params
+const { data: eventContent } = await loadQuery({ 
+  query: `*[_type == "type_event" && slug.current == '${event}'][0]{
+    _id,
+    title,
+    eyebrow,
+    description,
+    slug,
+    dateTime,
+    timezone,
+    use24hourFormat,
+    venue,
+    venueUrl,
+    location,
+    button{ label, url, newTab },
+    partnersHeading,
+    partnersSubheading,
+    speakersHeading,
+    speakersSubheading,
+    partnerLogos[]{${imageFields}},
+    speakers[]{ speakerName, speakerRole, speakerImage{${imageFields}}, speakerLogo{${imageFields}} },
+    thumbnailImage{${imageFields}},
+    globalSections{ sections[]{${globalSectionsFields}}},
+    metafields{ title, description, image }
+  }`
+})
+if (!eventContent) return Astro.redirect('/404')
 ---
 <LayoutEvent 
   content={eventContent}
+  locale={Locales.EN}
 />

--- a/src/pages/insights/[category]/[post].astro
+++ b/src/pages/insights/[category]/[post].astro
@@ -11,38 +11,36 @@ import { imageBaseFields } from '../../../lib/cms-queries';
 
 const { post, category } = Astro.params
 
-const [currentCategory, content] = await Promise.all([
-    sanityClient.fetch(`*[_type == "type_blogCategory" && defined(*[_type == "type_blog" && agencyBrand->name == '${Brands.DOMAINE}' && references(^._id)][0]) && slug.current == '${category}'][0]{ slug }`),
-    sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${Brands.DOMAINE}' && slug.current == '${post}'][0]{
-        title,
-        heading,
-        excerpt,
-        _id,
-        slug,
-        isHidden,
-        authors[]->{name, role, bio, image{${imageFields}}, department->{title} },
-        postDate,
-        thumbnailImage{${imageFields}},
-        category->{_id, title, slug}, 
-        body{
-            _type,
-            _key,
-            richContent[]{${richContentFields}},
-            translations{ 
-                ${Object.keys(Locales).filter(locale => Locales[locale] !== "en").map((locale) => (
-                `"${Locales[locale]}": ${Locales[locale]}[]{ _type, _key, children[]{${richContentFields}} }`
-                )
-            ).join()}
-            },
+const content =sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${Brands.DOMAINE}' && slug.current == '${post}'][0]{
+    title,
+    heading,
+    excerpt,
+    _id,
+    slug,
+    isHidden,
+    authors[]->{name, role, bio, image{${imageFields}}, department->{title} },
+    postDate,
+    thumbnailImage{${imageFields}},
+    category->{_id, title, slug}, 
+    body{
+        _type,
+        _key,
+        richContent[]{${richContentFields}},
+        translations{ 
+            ${Object.keys(Locales).filter(locale => Locales[locale] !== "en").map((locale) => (
+            `"${Locales[locale]}": ${Locales[locale]}[]{ _type, _key, children[]{${richContentFields}} }`
+            )
+        ).join()}
         },
-        services[]->{_id, title, slug, serviceGroup->{_id, title, slug}},
-        agencyBrand->{slug, name },
-        globalSections{ sections[]{${globalSectionsFields}} },
-        metafields{ title, description, image{${imageBaseFields}} },
-    }`)
-])
+    },
+    services[]->{_id, title, slug, serviceGroup->{_id, title, slug}},
+    agencyBrand->{slug, name },
+    globalSections{ sections[]{${globalSectionsFields}} },
+    metafields{ title, description, image{${imageBaseFields}} },
+}`
+)
 
-if (!currentCategory || !content) return Astro.redirect('/404')
+if (!content || content.category.slug.current !== category) return Astro.redirect('/404')
 ---
 <LayoutBlogPost
   content={content}

--- a/src/pages/studio/[...page].astro
+++ b/src/pages/studio/[...page].astro
@@ -3,29 +3,13 @@ import LayoutPage from "../../layouts/Layout-Page.astro";
 import { Brands } from "../../enums/brands";
 import LayoutMarketingPage from "../../layouts/Layout_MarketingPage.astro";
 import { loadQuery } from "../../lib/sanity-load-query";
-import { globalSectionsFields, imageFields, videoFields, imageBaseFields, generalPageFields } from "../../lib/cms-queries";
-import { getEnv } from "../../lib/getEnv";
-
-export const prerender = false;
-
-// export async function getStaticPaths() {
-//     const { data: pages } = await loadQuery({ 
-//         query: `*[_type == "page_studio-general"]{${generalPageFields}} | order(_createdAt desc)`
-//     })
-    
-//     return pages.map((page) => {
-//         return {
-//             params: { page: page.slug.current },
-//             props: { content: page }
-//         }
-//     })
-// }
+import { generalPageFields } from "../../lib/cms-queries";
 
 const { page } = Astro.params
 const { data: pageContent } = await loadQuery({ 
     query: `*[ _type == "page_studio-general" && slug.current == '${page}'][0]{${generalPageFields}}`
 })
-
+if (!pageContent) return Astro.redirect('/404')
 ---
 {pageContent.isMarketingPage ? 
     <LayoutMarketingPage

--- a/src/pages/studio/index.astro
+++ b/src/pages/studio/index.astro
@@ -1,4 +1,5 @@
 ---
+// STATIC ROUTE
 import LayoutStudioHome from "../../layouts/Layout-Studio_Home.astro";
 import { loadQuery } from "../../lib/sanity-load-query";
 import { globalSectionsFields, imageFields, videoFields, imageBaseFields, projectGridFields } from "../../lib/cms-queries";
@@ -15,6 +16,8 @@ const { data: pageSettings } = await loadQuery({
     },
   }`
 })
+
+export const prerender = true // Make page static so it doesn't refetch on each page load
 ---
 <LayoutStudioHome 
     content={pageSettings}

--- a/src/pages/studio/insights/[category]/[post].astro
+++ b/src/pages/studio/insights/[category]/[post].astro
@@ -1,40 +1,49 @@
 ---
+// SERVER RENDERED AT LOAD TIME
 import LayoutBlogPost from '../../../../layouts/Layout_BlogPost.astro';
 import { Brands } from '../../../../enums/brands';
-import { getBlogPosts } from '../../../../lib/cached-content';
-import { getEnv } from '../../../../lib/getEnv';
+import { sanityClient } from 'sanity:client';
+import { imageFields } from '../../../../lib/cms-queries';
+import { richContentFields } from '../../../../lib/cms-queries';
+import { Locales } from '../../../../enums/locales';
+import { globalSectionsFields } from '../../../../lib/cms-queries';
+import { imageBaseFields } from '../../../../lib/cms-queries';
 
-export const prerender = false // Make Blog Post content static so it doesn't refetch on each page load
+const { post, category } = Astro.params
 
-export async function getStaticPaths() {
-    const blogPosts = await getBlogPosts(Brands.STUDIO)
-    return blogPosts.map((post) => {
-        return {
-            params: { 
-                post: post.slug.current, 
-                category: post.category.slug.current 
-            },
-            props: { 
-                content: post 
-            }
-        }
-    })
-}
+const content = await sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${Brands.STUDIO}' && slug.current == '${post}'][0]{
+    title,
+    heading,
+    excerpt,
+    _id,
+    slug,
+    isHidden,
+    authors[]->{name, role, bio, image{${imageFields}}, department->{title} },
+    postDate,
+    thumbnailImage{${imageFields}},
+    category->{_id, title, slug}, 
+    body{
+        _type,
+        _key,
+        richContent[]{${richContentFields}},
+        translations{ 
+            ${Object.keys(Locales).filter(locale => Locales[locale] !== "en").map((locale) => (
+            `"${Locales[locale]}": ${Locales[locale]}[]{ _type, _key, children[]{${richContentFields}} }`
+            )
+        ).join()}
+        },
+    },
+    services[]->{_id, title, slug, serviceGroup->{_id, title, slug}},
+    agencyBrand->{slug, name },
+    globalSections{ sections[]{${globalSectionsFields}} },
+    metafields{ title, description, image{${imageBaseFields}} },
+}`
+)
 
-let blogPostContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    console.log('render SERVER')
-    const { post } = Astro.params
-    const blogPosts = await getBlogPosts(Brands.STUDIO)
-    blogPostContent = blogPosts.find(p => p.slug.current === post)
-} else {
-    console.log('render STATIC')
-    const { content } = Astro.props
-    blogPostContent = content
-}
+if (!content || content.category.slug.current !== category) return Astro.redirect('/404')
 ---
 <LayoutBlogPost
-  content={blogPostContent}
+  content={content}
   brand={Brands.STUDIO}
+  locale={Locales.EN}
 />

--- a/src/pages/studio/insights/[category]/index.astro
+++ b/src/pages/studio/insights/[category]/index.astro
@@ -1,52 +1,30 @@
 ---
+import { Locales } from '../../../../enums/locales';
 import { Brands } from '../../../../enums/brands';
 import LayoutBlogIndex from '../../../../layouts/Layout_BlogIndex.astro';
-import { blogCardFields, urlFor } from '../../../../lib/cms-queries';
-import { getBlogCategories } from '../../../../lib/cached-content';
+import { blogCardFields, imageBaseFields, urlFor } from '../../../../lib/cms-queries';
 import { sanityClient } from 'sanity:client';
-import { loadQuery } from '../../../../lib/sanity-load-query';
-import { getEnv } from '../../../../lib/getEnv';
 
-export const prerender = false // Make Blog Category content static so it doesn't refetch on each page load
+const { category } = Astro.params
 
-export async function getStaticPaths() {
-    const categories = await getBlogCategories(Brands.STUDIO)
-    return categories.map((category) => {
-        return {
-            params: { 
-                category: category.slug.current
-            },
-            props: { content: category }
-        }
-    })
-}
-
-let blogCategoryContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { category } = Astro.params
-    const categories = await getBlogCategories(Brands.STUDIO)
-    blogCategoryContent = categories.find(cat => cat.slug.current === category)
-} else {
-    const { content } = Astro.props
-    blogCategoryContent = content
-}
-
-const { data: pageSettings } = await loadQuery({ 
-  query: `*[_type == "page_blog-index" && _id == "page_blog-index-studio"][0]`
-})
-const blogPosts = await sanityClient.fetch(`*[_type == "type_blog" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && category->slug.current == '${blogCategoryContent.slug.current}' ]{${blogCardFields}}|order(postDate desc)`)
+const categoryContent = await sanityClient.fetch(`
+*[_type == "type_blogCategory" && slug.current == '${category}'][0]{
+    title,
+    heading,
+    slug,
+    "posts": *[_type == "type_blog" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && category->slug.current == '${category}' ]{ ${blogCardFields} }|order(postDate desc),
+    metafields{ title, description, image{${imageBaseFields}} }
+}`)
+if (!categoryContent || categoryContent.posts.length === 0) return Astro.redirect('/404')
 ---
 <LayoutBlogIndex
-    title={pageSettings.metafields?.title ? pageSettings.metafields.title : pageSettings.title}
-    description={pageSettings.metafields?.description ? pageSettings.metafields.description : null}
-    image={pageSettings.metafields?.image ? urlFor(pageSettings.metafields.image).url() : null}
-    pageSettings={pageSettings}
-    blogPosts={blogPosts}
-    heading={pageSettings.title}
-    subheading={pageSettings.heading}
-    searchFilter="type:page"
-    showPreloader={false}
+    blogPosts={categoryContent.posts}
+    title={categoryContent.metafields?.title ? categoryContent.metafields.title : categoryContent.title}
+    description={categoryContent.metafields?.description ? categoryContent.metafields.description : null}
+    image={categoryContent.metafields?.image ? urlFor(categoryContent.metafields.image).url() : null}
+    heading={categoryContent.title}
+    subheading={categoryContent.heading}
+    slug={categoryContent.slug}
     brand={Brands.STUDIO}
-    slug={blogCategoryContent.slug}
+    locale={Locales.EN}
 />

--- a/src/pages/studio/insights/index.astro
+++ b/src/pages/studio/insights/index.astro
@@ -1,9 +1,15 @@
 ---
+import { getCollection } from 'astro:content';
 import { Brands } from '../../../enums/brands';
 import LayoutBlogIndex from '../../../layouts/Layout_BlogIndex.astro';
+import { Locales } from '../../../enums/locales';
 
-export const prerender = false // Make Blog Index content static so it doesn't refetch on each page load
+export const prerender = true // Make Blog Index content static so it doesn't refetch on each page load
+
+const blogCards = await getCollection('blogCards', ({ data }) => data.agencyBrand.name === Brands.STUDIO)
 ---
 <LayoutBlogIndex
   brand={Brands.STUDIO}
+  blogPosts={blogCards.map(blog => blog.data)}
+  locale={Locales.EN}
 />

--- a/src/pages/studio/services/[service_type]/[service_group]/[service].astro
+++ b/src/pages/studio/services/[service_type]/[service_group]/[service].astro
@@ -1,40 +1,45 @@
 ---
 import LayoutService from "../../../../../layouts/Layout_Service.astro"
 import { Brands } from "../../../../../enums/brands"
-import { getServices } from "../../../../../lib/cached-content";
-import { getEnv } from "../../../../../lib/getEnv";
+import { sanityClient } from "sanity:client";
+import { globalSectionsFields } from "../../../../../lib/cms-queries";
+import { imageBaseFields } from "../../../../../lib/cms-queries";
+import { Locales } from "../../../../../enums/locales";
 
-export const prerender = false // Make Service content static so it doesn't refetch on each page load
+const { service, service_group, service_type } = Astro.params
 
-export async function getStaticPaths() {
-    const services = await getServices(Brands.STUDIO)
-    return services.map((service) => {
-        return {
-            params: { 
-                service: service.slug.current,
-                service_group: service.serviceGroup.slug.current,
-                service_type: service.serviceGroup.serviceType.slug.current
-            },
-            props: { 
-                content: service
-            }
+const serviceContent = await sanityClient.fetch(`*[_type == "type_service" && '${Brands.STUDIO}' in agencyBrands[]->name && slug.current == '${service}'][0]{
+    title,
+    slug,
+    excerpt,
+    description,
+    formHeading,
+    formText,
+    hubspotFormId,
+    agencyBrands[]->{ name },
+    serviceGroup->{
+        title,
+        slug,
+        formHeading,
+        formText,
+        hubspotFormId,
+        serviceType->{
+            title,
+            slug,
+            formHeading,
+            formText,
+            hubspotFormId
         }
-    })
-}
-
-let serviceContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { service, service_type } = Astro.params
-    const services = await getServices(Brands.STUDIO)
-    serviceContent = services.find(s => s.slug.current === service)
-} else {
-    const { content } = Astro.props
-    serviceContent = content
-}
+    },
+    pageSectionsStudio[]{${globalSectionsFields}},
+    metafields{ title, description, image{${imageBaseFields}} },
+  }`
+)
+if (!serviceContent || serviceContent.serviceGroup.slug.current !== service_group || serviceContent.serviceGroup.serviceType.slug.current !== service_type) return Astro.redirect('/404')
 ---
 <LayoutService
     content={serviceContent}
     brand={Brands.STUDIO}
     activePath="/studio/services"
+    locale={Locales.EN}
 />

--- a/src/pages/studio/services/[service_type]/[service_group]/index.astro
+++ b/src/pages/studio/services/[service_type]/[service_group]/index.astro
@@ -1,39 +1,47 @@
 ---
 import LayoutServiceGroup from "../../../../../layouts/Layout_ServiceGroup.astro"
 import { Brands } from "../../../../../enums/brands"
-import { getServiceGroups } from "../../../../../lib/cached-content";
-import { getEnv } from "../../../../../lib/getEnv";
+import { globalSectionsFields } from "../../../../../lib/cms-queries";
+import { imageBaseFields } from "../../../../../lib/cms-queries";
+import { imageFields } from "../../../../../lib/cms-queries";
+import { sanityClient } from "sanity:client";
+import { Locales } from "../../../../../enums/locales";
 
-export const prerender = false // Make Service Group content static so it doesn't refetch on each page load
+const { service_type, service_group } = Astro.params
 
-export async function getStaticPaths() {
-    const serviceGroups = await getServiceGroups(Brands.STUDIO)
-    return serviceGroups.map((serviceGroup) => {
-        return {
-            params: { 
-                service_group: serviceGroup.slug.current,
-                service_type: serviceGroup.serviceType.slug.current
-            },
-            props: { 
-                content: serviceGroup
-            }
-        }
-    })
-}
-
-let serviceGroupContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { service_type, service_group } = Astro.params
-    const serviceGroups = await getServiceGroups(Brands.STUDIO)
-    serviceGroupContent = serviceGroups.find(sg => sg.slug.current === service_group)
-} else {
-    const { content } = Astro.props
-    serviceGroupContent = content
-}
+const serviceGroupContent = await sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.STUDIO}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
+  title,
+  slug,
+  isHidden,
+  excerpt,
+  description,
+  formHeading,
+  formText,
+  hubspotFormId,
+  orderRank,
+  images[]{${imageFields}},
+  agencyBrands[]->{ _id, name, slug },
+  serviceType->{ _id, title, slug, formHeading, formText, hubspotFormId },
+  "services": *[_type == "type_service" && references(^._id)]{
+    _id,
+    title,
+    slug,
+    isHidden,
+    excerpt,
+    description,
+    orderRank,
+    agencyBrands[]->{ _id, name, slug },
+    serviceGroup->{ _id, title, slug, serviceType->{ _id, title, slug } },
+    metafields{ title, description, image{${imageBaseFields}} }
+  } | order(orderRank),
+  metafields{ title, description, image{${imageBaseFields}} },
+  pageSectionsStudio[]{${globalSectionsFields}}
+}`)
+if (!serviceGroupContent || serviceGroupContent.serviceType?.slug.current !== service_type) return Astro.redirect('/404')
 ---
 <LayoutServiceGroup 
     content={serviceGroupContent}
     brand={Brands.STUDIO}
     activePath="/studio/services"
+    locale={Locales.EN}
 />

--- a/src/pages/studio/services/[service_type]/index.astro
+++ b/src/pages/studio/services/[service_type]/index.astro
@@ -1,34 +1,48 @@
 ---
+// SERVER RENDERED
 import LayoutServiceType from "../../../../layouts/Layout_ServiceType.astro"
 import { Brands } from "../../../../enums/brands"
-import { getServiceTypes } from "../../../../lib/cached-content";
-import { getEnv } from "../../../../lib/getEnv";
+import { sanityClient } from "sanity:client";
+import { globalSectionsFields } from "../../../../lib/cms-queries";
+import { imageBaseFields } from "../../../../lib/cms-queries";
+import { imageFields } from "../../../../lib/cms-queries";
+import { Locales } from "../../../../enums/locales";
 
-export const prerender = false // Make Service Type content static so it doesn't refetch on each page load
-
-export async function getStaticPaths() {
-    const serviceTypes = await getServiceTypes(Brands.STUDIO)
-    return serviceTypes.map((serviceType) => {
-        return {
-            params: { service_type: serviceType.slug.current },
-            props: { content: serviceType }
-        }
-    })
-}
-
-let serviceTypeContent
-
-if (getEnv('PUBLIC_SERVER_RENDERING_ENABLED', Astro.locals) === "true") {
-    const { service_type } = Astro.params
-    const serviceTypes = await getServiceTypes(Brands.STUDIO)
-    serviceTypeContent = serviceTypes.find(st => st.slug.current === service_type)
-} else {
-    const { content } = Astro.props
-    serviceTypeContent = content
-}
+const { service_type } = Astro.params
+const serviceTypeContent = await sanityClient.fetch(`*[_type == "type_serviceType" && slug.current == '${service_type}'][0]{
+    _id,
+    title,
+    description,
+    slug,
+    agencyBrands[]->{ _id, name, slug },
+    pageSectionsStudio[]{${globalSectionsFields}},
+    "serviceGroups": *[_type == "type_serviceGroup" && references(^._id) ]{
+        _id,
+        title,
+        description,
+        slug,
+        orderRank,
+        serviceType->{slug},
+        "services": *[_type == "type_service" && references(^._id)] {
+            _id,
+            title,
+            description,
+            slug,
+            orderRank
+        } | order(orderRank)
+    } | order(orderRank),
+    isHidden,
+    excerpt,
+    images[]{${imageFields}},
+    metafields{ title, description, image{${imageBaseFields}} },
+    orderRank
+}`
+)
+if (!serviceTypeContent) return Astro.redirect('/404')
 ---
 <LayoutServiceType 
     content={serviceTypeContent}
     activePath="/studio/services"
     brand={Brands.STUDIO}
+    locale={Locales.EN}
 />

--- a/src/pages/studio/services/index.astro
+++ b/src/pages/studio/services/index.astro
@@ -1,7 +1,12 @@
 ---
+// STATIC ROUTE
+import { Locales } from "../../../enums/locales";
 import { Brands } from "../../../enums/brands";
 import LayoutStudioServicesIndex from "../../../layouts/Layout-Studio_ServicesIndex.astro";
+
+export const prerender = true // Make page static so it doesn't refetch on each page load
 ---
 <LayoutStudioServicesIndex
   brand={Brands.STUDIO}
+  locale={Locales.EN}
 />

--- a/src/pages/studio/styleguide.astro
+++ b/src/pages/studio/styleguide.astro
@@ -1,9 +1,11 @@
 ---
+// STATIC ROUTE
 import StyleguideContent from '../../components/global/styleguide/Styleguide-Content.astro';
 import LayoutStudio from '../../layouts/Layout-Studio.astro';
+
+export const prerender = true // Make page static so it doesn't refetch on each page load
 ---
-<LayoutStudio 
-  theme="dark"
+<LayoutStudio
   title="Styleguide"
   showPreloader={false}
 >

--- a/src/pages/studio/work/[project].astro
+++ b/src/pages/studio/work/[project].astro
@@ -1,26 +1,40 @@
 ---
 import LayoutProject from '../../../layouts/Layout_Project.astro';
 import { Brands } from '../../../enums/brands';
-import { getProjects } from '../../../lib/cached-content';
-import { getEnv } from '../../../lib/getEnv';
-
-export const prerender = false // Make Project content static so it doesn't refetch on each page load
-
-export async function getStaticPaths() {
-    const projects = await getProjects(Brands.STUDIO)
-    return projects.map((project) => {
-        return {
-            params: { project: project.slug.current },
-            props: { content: project }
-        }
-    })
-}
-
-let projectContent
+import { sanityClient } from 'sanity:client';
+import { imageBaseFields } from '../../../lib/cms-queries';
+import { imageFields } from '../../../lib/cms-queries';
+import { videoFields } from '../../../lib/cms-queries';
+import { globalSectionsFields } from '../../../lib/cms-queries';
 
 const { project } = Astro.params
-const projects = await getProjects(Brands.STUDIO)
-projectContent = projects.find(p => p.slug.current === project)
+const projectContent = await sanityClient.fetch(`*[_type == "type_project" && isHidden != true && agencyBrand->name == '${Brands.STUDIO}' && slug.current == '${project}']{
+      title,
+      isHidden,
+      description,
+      excerpt,
+      industry->{ slug, title },
+      url,
+      client->{ slug, title, logoDark{${imageBaseFields}}, logoLight{${imageBaseFields}}, isEnterprise, "logo": logo.asset->url },
+      foregroundColor,
+      backgroundColor,
+      accentColor,
+      services[]->{ title, slug, serviceGroup->{slug, title, serviceType->{slug} } },
+      features[]->{ title, slug },
+      partners[]->{ title, excerpt, slug, icon{${imageFields}}, tier->{ createLandingPages}, websiteUrl },
+      metrics[]{ label, number },
+      awards[]{ awardTitle, publication },
+      agencyBrand->{slug, name},
+      thumbnailMedia{${videoFields}, ${imageFields}},
+      thumbnailImageSecondary{${imageFields}},
+      slug,
+      heroMedia{${videoFields}, ${imageFields}},
+      sections[]{${globalSectionsFields}},
+      metafields{ title, description, image{${imageBaseFields}} },
+      orderRank,
+  }[0]`
+)
+if (projectContent === null) return Astro.redirect('/404')
 ---
 <LayoutProject
     content={projectContent}

--- a/src/pages/studio/work/features/[feature].astro
+++ b/src/pages/studio/work/features/[feature].astro
@@ -4,23 +4,20 @@ import LayoutProjectsIndex from '../../../../layouts/Layout_ProjectsIndex.astro'
 import { Brands } from '../../../../enums/brands';
 import { imageBaseFields, projectGridFields } from '../../../../lib/cms-queries';
 import { loadQuery } from '../../../../lib/sanity-load-query';
+import { sanityClient } from 'sanity:client';
 
 const { feature } = Astro.params
-const { data: featureContent } = await loadQuery({
-    query: `
-    *[_type == "type_projectFeature" && defined(*[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && references(^._id) ][0]) && slug.current == '${feature}'][0]{
+const featureContent = await sanityClient.fetch(`
+    *[_type == "type_projectFeature" && slug.current == '${feature}'][0]{
         _id,
         title,
         excerpt,
         slug, 
-        "hasContent": {
-        "${Brands.STUDIO}": defined(*[_type == "type_project" && isHidden != true && agencyBrand->name == '${Brands.STUDIO}' && references(^._id)][0]),
-        },
-        "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && ^.slug.current in features[]->slug.current ]{${projectGridFields}} | order(orderRank),
+        "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && references(^._id) ]{ ${projectGridFields} } | order(orderRank),
         metafields{ title, description, image{${imageBaseFields}} },
     }`
-})
-if (!featureContent) return Astro.redirect('/404')
+)
+if (!featureContent || featureContent.projects.length === 0) return Astro.redirect('/404')
 ---
 <LayoutProjectsIndex 
     content={featureContent}

--- a/src/pages/studio/work/industries/[industry].astro
+++ b/src/pages/studio/work/industries/[industry].astro
@@ -2,21 +2,21 @@
 // SERVER RENDERED AT LOAD TIME
 import LayoutProjectsIndex from '../../../../layouts/Layout_ProjectsIndex.astro';
 import { Brands } from '../../../../enums/brands';
-import { projectGridFields } from '../../../../lib/cms-queries';
-import { loadQuery } from '../../../../lib/sanity-load-query';
+import { imageBaseFields, projectGridFields } from '../../../../lib/cms-queries';
+import { sanityClient } from 'sanity:client';
 
 const { industry } = Astro.params
-const { data: industryContent } = await loadQuery({
-    query: `*[_type == "type_industry" && defined(*[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && references(^._id)][0]) && slug.current == '${industry}'][0]{ 
-    ...,
-    "hasContent": {
-      "${Brands.STUDIO}": defined(*[_type == "type_project" && isHidden != true && agencyBrand->name == '${Brands.STUDIO}' && references(^._id)][0]),
-    },
+const industryContent = await sanityClient.fetch(`*[_type == "type_industry" && slug.current == '${industry}'][0]{ 
+    _id,
+    title,
+    slug,
+    description,
     excerpt,
-    "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && industry->slug.current == ^.slug.current ]{${projectGridFields}} | order(orderRank),
+    "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && references(^._id) ]{ ${projectGridFields} } | order(orderRank),
+    metafields{ title, description, image{${imageBaseFields}} },
   }`
-})
-if (!industryContent) return Astro.redirect('/404')
+)
+if (!industryContent || industryContent.projects.length === 0) return Astro.redirect('/404')
 ---
 <LayoutProjectsIndex
     content={industryContent}

--- a/src/pages/studio/work/partners/[partner].astro
+++ b/src/pages/studio/work/partners/[partner].astro
@@ -3,34 +3,19 @@
 import LayoutProjectsIndex from '../../../../layouts/Layout_ProjectsIndex.astro';
 import { Brands } from '../../../../enums/brands';
 import { projectGridFields } from '../../../../lib/cms-queries';
-import { getPartners } from '../../../../lib/cached-content';
 import { sanityClient } from 'sanity:client';
-import { getEnv } from '../../../../lib/getEnv';
-import { loadQuery } from '../../../../lib/sanity-load-query';
 
 const { partner } = Astro.params
-const { data: partnerContent } = await loadQuery({
-    query: `*[_type == "type_partner" && defined(*[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && references(^._id)][0]) && slug.current == '${partner}'][0]{
-        _id,
-        title, 
-        slug, 
-        excerpt,
-        description,
-        tier->{slug, title, createLandingPages},
-        "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true  && ^.slug.current in partners[]->slug.current ]{${projectGridFields}} | order(orderRank),
-        websiteUrl, 
-        websiteText,
-        instagramUrl,
-        twitterUrl,
-        linkedInUrl,
-        youTubeUrl,
-        tikTokUrl,
-        "hasContent": {
-            "${Brands.STUDIO}": defined(*[_type == "type_project" && isHidden != true && agencyBrand->name == '${Brands.STUDIO}' && references(^._id)][0]),
-        },
-    }`
-})
-if (!partnerContent) return Astro.redirect('/404')
+const partnerContent = await sanityClient.fetch(`*[_type == "type_partner" && slug.current == '${partner}'][0]{
+    _id,
+    title, 
+    slug, 
+    excerpt,
+    description,
+    tier->{slug, title, createLandingPages},
+    "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true  && references(^._id) ]{ ${projectGridFields} } | order(orderRank),
+}`)
+if (!partnerContent || partnerContent.projects.length === 0) return Astro.redirect('/404')
 ---
 <LayoutProjectsIndex
     content={partnerContent}

--- a/src/pages/studio/work/service-groups/[service_group].astro
+++ b/src/pages/studio/work/service-groups/[service_group].astro
@@ -3,24 +3,20 @@
 import LayoutProjectsIndex from '../../../../layouts/Layout_ProjectsIndex.astro';
 import { Brands } from '../../../../enums/brands';
 import { imageFields, projectGridFields } from '../../../../lib/cms-queries';
-import { loadQuery } from '../../../../lib/sanity-load-query';
+import { sanityClient } from 'sanity:client';
 
 const { service_group } = Astro.params
-const { data: serviceGroupContent } = await loadQuery({
-    query: `*[_type == "type_serviceGroup" && '${Brands.STUDIO}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
+const serviceGroupContent = await sanityClient.fetch(`*[_type == "type_serviceGroup" && '${Brands.STUDIO}' in agencyBrands[]->name && slug.current == '${service_group}'][0]{
     ...,
     isHidden,
     excerpt,
     description,
     images[]{${imageFields}},
     agencyBrands[]->{..., slug },
-    "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && ^.slug.current in services[]->serviceGroup->slug.current ]{${projectGridFields}} | order(orderRank),
-    "hasContent": {
-      "${Brands.STUDIO}": defined(*[_type == "type_project" && isHidden != true && agencyBrand->name == '${Brands.STUDIO}' && ^._id in services[]->serviceGroup._ref ][0]),
-    },
+    "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && references(*[_type == "type_service" && serviceGroup->slug.current == '${service_group}']._id) ]{ ${projectGridFields} } | order(orderRank),
   }`
-})
-if (!serviceGroupContent) return Astro.redirect('/404')
+)
+if (!serviceGroupContent || serviceGroupContent.projects.length === 0) return Astro.redirect('/404')
 ---
 <LayoutProjectsIndex
     content={serviceGroupContent}

--- a/src/pages/studio/work/services/[service].astro
+++ b/src/pages/studio/work/services/[service].astro
@@ -3,19 +3,21 @@ import LayoutProjectsIndex from '../../../../layouts/Layout_ProjectsIndex.astro'
 import { Brands } from '../../../../enums/brands';
 import { projectGridFields, projectsGridQuery } from '../../../../lib/cms-queries';
 import { loadQuery } from '../../../../lib/sanity-load-query';
+import { sanityClient } from 'sanity:client';
 
 const { service } = Astro.params
-const { data: serviceContent } = await loadQuery({
-    query: `*[_type == "type_service" && '${Brands.STUDIO}' in agencyBrands[]->name && slug.current == '${service}'][0]{
-    ...,
+const serviceContent = await sanityClient.fetch(`*[_type == "type_service" && '${Brands.STUDIO}' in agencyBrands[]->name && slug.current == '${service}'][0]{
+    _id,
+    title,
+    slug,
     isHidden,
     excerpt,
     description,
-    "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && ^.slug.current in services[]->slug.current ]{${projectGridFields}} | order(orderRank),
-    agencyBrands[]->{..., slug, name},
+    "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.STUDIO}' && isHidden != true && references(^._id) ]{ ${projectGridFields} } | order(orderRank),
+    agencyBrands[]->{ _id, slug, name},
   }`
-})
-if (!serviceContent) return Astro.redirect('/404')
+)
+if (!serviceContent || serviceContent.projects.length === 0) return Astro.redirect('/404')
 ---
 <LayoutProjectsIndex
     content={serviceContent}

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -1,6 +1,9 @@
 ---
+// STATIC ROUTE
 import StyleguideContent from '../components/global/styleguide/Styleguide-Content.astro';
 import LayoutDomaine from '../layouts/Layout-Domaine.astro';
+
+export const prerender = true // Make page static so it doesn't refetch on each page load
 ---
 <LayoutDomaine 
   theme="dark"

--- a/src/pages/work/[project].astro
+++ b/src/pages/work/[project].astro
@@ -9,31 +9,31 @@ import { sanityClient } from 'sanity:client';
 
 const { project } = Astro.params
 const projectContent = await sanityClient.fetch(`*[_type == "type_project" && isHidden != true && agencyBrand->name == '${Brands.DOMAINE}' && slug.current == '${project}']{
-        title,
-        isHidden,
-        description,
-        excerpt,
-        industry->{ slug, title },
-        url,
-        client->{ slug, title, logoDark{${imageBaseFields}}, logoLight{${imageBaseFields}}, isEnterprise, "logo": logo.asset->url },
-        foregroundColor,
-        backgroundColor,
-        accentColor,
-        services[]->{ title, slug, serviceGroup->{slug, title, serviceType->{slug} } },
-        features[]->{ title, slug },
-        partners[]->{ title, excerpt, slug, icon{${imageFields}}, tier->{ createLandingPages}, websiteUrl },
-        metrics[]{ label, number },
-        awards[]{ awardTitle, publication },
-        agencyBrand->{slug, name},
-        thumbnailMedia{${videoFields}, ${imageFields}},
-        thumbnailImageSecondary{${imageFields}},
-        slug,
-        heroMedia{${videoFields}, ${imageFields}},
-        sections[]{${globalSectionsFields}},
-        metafields{ title, description, image{${imageBaseFields}} },
-        orderRank,
-    }[0]`
-  )
+      title,
+      isHidden,
+      description,
+      excerpt,
+      industry->{ slug, title },
+      url,
+      client->{ slug, title, logoDark{${imageBaseFields}}, logoLight{${imageBaseFields}}, isEnterprise, "logo": logo.asset->url },
+      foregroundColor,
+      backgroundColor,
+      accentColor,
+      services[]->{ title, slug, serviceGroup->{slug, title, serviceType->{slug} } },
+      features[]->{ title, slug },
+      partners[]->{ title, excerpt, slug, icon{${imageFields}}, tier->{ createLandingPages}, websiteUrl },
+      metrics[]{ label, number },
+      awards[]{ awardTitle, publication },
+      agencyBrand->{slug, name},
+      thumbnailMedia{${videoFields}, ${imageFields}},
+      thumbnailImageSecondary{${imageFields}},
+      slug,
+      heroMedia{${videoFields}, ${imageFields}},
+      sections[]{${globalSectionsFields}},
+      metafields{ title, description, image{${imageBaseFields}} },
+      orderRank,
+  }[0]`
+)
 if (projectContent === null) return Astro.redirect('/404')
 ---
 <LayoutProject 

--- a/src/pages/work/features/[feature].astro
+++ b/src/pages/work/features/[feature].astro
@@ -18,8 +18,6 @@ const featureContent = await sanityClient.fetch(`
     }`
 )
 if (!featureContent || featureContent.projects.length === 0) return Astro.redirect('/404')
-
-// const projects = await getCollection('projectCards', ({ data }) => data.agencyBrand.name === Brands.DOMAINE && data.isHidden !== true && data.features.some(feature => feature.slug.current == featureContent.slug.current) )
 ---
 <LayoutProjectsIndex 
     content={featureContent}

--- a/src/pages/work/services/[service].astro
+++ b/src/pages/work/services/[service].astro
@@ -8,12 +8,14 @@ import { getCollection } from 'astro:content';
 
 const { service } = Astro.params
 const serviceContent = await sanityClient.fetch(`*[_type == "type_service" && '${Brands.DOMAINE}' in agencyBrands[]->name && slug.current == '${service}'][0]{
-    ...,
+    _id,
+    title,
+    slug,
     isHidden,
     excerpt,
     description,
     "projects": *[_type == "type_project" && agencyBrand->name == '${Brands.DOMAINE}' && isHidden != true && references(^._id) ]{ ${projectGridFields} } | order(orderRank),
-    agencyBrands[]->{..., slug, name},
+    agencyBrands[]->{ _id, slug, name},
   }`
 )
 if (!serviceContent || serviceContent.projects.length === 0) return Astro.redirect('/404')


### PR DESCRIPTION
- **Remove srcset calcs**
- **Optimize Sanity queries**
- **Remove project definition in Sanity queries**
- **Try client prerender**
- **Remove viewport anim from project card**
- **Temp hide global elements**
- **Hide notification menu + footer**
- **Remove getSVG from project card**
- **Respect logo color via css**
- **Image optimizations**
- **Various optimizations**
- **Remove Astro img**
- **Try Sanity cache headers**
- **Test different fetch strategies**
- **Server defer grid**
- **Move back to Sanity queries directly**
- **Try to optimize filter sanity queries**
- **Dont filter project filters by hasContent**
- **Remove redundant await**
- **Header and Menu fetch optimizations**
- **Optimize blog fetches**
- **Keep queries separate in blog post**
- **Try SSG for all services pages**
- **Make sure Promise works with mixed fetches**
- **blog post optimizations**
- **Service Type page SSR**
- **Service Group page SSR**
- **Service page SSR**
- **Partners pages SSR - fix video aspect ratio on Partners**
- **Service pages optimizations**
- **Await serviceGroup query**
- **Optimize filter query content**
- **Remove spread operators**
- **Remove front chat**
- **Clear time intervals, causing Cloudflare timeouts**
- **SSR all Studio pages + events**
- **Make first 3 project cards eager**
- **Add eager to first 3 blog cards in grid**
